### PR TITLE
Added mode for domestic hot water only

### DIFF
--- a/custom_components/besmart/climate.py
+++ b/custom_components/besmart/climate.py
@@ -357,6 +357,7 @@ class Thermostat(ClimateDevice):
     ECONOMY = 2  # 'Holiday - Economy'
     PARTY = 3  # 'Party - Confort'
     IDLE = 4  # 'Spento - Antigelo'
+    DHW = 5 # 'Sanitario - Domestic hot water only'
 
     PRESET_HA_TO_BESMART = {
         "AUTO": AUTO,
@@ -364,6 +365,7 @@ class Thermostat(ClimateDevice):
         "ECO": ECONOMY,
         "PARTY": PARTY,
         "IDLE": IDLE,
+        "DHW": DHW,
     }
 
     PRESET_BESMART_TO_HA = {
@@ -372,6 +374,7 @@ class Thermostat(ClimateDevice):
         ECONOMY: "ECO",
         PARTY: "PARTY",
         IDLE: "IDLE",
+        DHW: "DHW",
     }
     PRESET_MODE_LIST = list(PRESET_HA_TO_BESMART)
 


### PR DESCRIPTION
I wasn't able to put my BeSmart thermostats in dwh mode only, analyzing the getRoomData196 json I realized there's a 6th mode (id=5) to put thermostats in domestic hot water mode only.
My devices are connected via OTbus, and this triggers the boiler into summer mode. when you switch back to any other mode, the boiler goes back to winter mode.