### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/besmart/climate.py
+++ b/custom_components/besmart/climate.py
@@ -454,7 +454,7 @@ class Thermostat(ClimateDevice):
                 self._tempSetMark = "2"
 
             try:
-                self._battery = bool(data.get("bat", "0"))
+                self._battery =not bool(int(data.get("bat"))) #corrected to raise battery alert in ha 1=problem status false
             except ValueError:
                 self._battery = "0"
 


### PR DESCRIPTION
the old code alway returned true. casting to a boolean a string.
in addition i've reversed the boolean to raise in ha the status false when a battery has a problem. 
tested in my real case environment.
Battery almost empty leads to "bat: 1" .