### PR TITLE
change device_state_attributes no more working

### DIFF
--- a/custom_components/besmart/climate.py
+++ b/custom_components/besmart/climate.py
@@ -490,7 +490,7 @@ class Thermostat(ClimateEntity):
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the device specific state attributes."""
         return {
             ATTR_MODE: self._current_state,


### PR DESCRIPTION
Since a breaking change in the climate component (someting like january 2022...) def extra_state_attributes(self):   have to sobstitute def device_state_attributes(self):

I found this tryin to undestrand why the battery state was no more exposed...